### PR TITLE
[JBWS-3997] usage of Exception.printStackTrace() instead of logging feature

### DIFF
--- a/src/main/java/org/jboss/ws/common/concurrent/CopyJob.java
+++ b/src/main/java/org/jboss/ws/common/concurrent/CopyJob.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.ws.common.concurrent;
 
+import org.jboss.logging.Logger;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -46,6 +48,7 @@ import java.io.OutputStream;
  */
 public final class CopyJob implements Runnable
 {
+   private static Logger log = Logger.getLogger(CopyJob.class);
 
    /**
     * Input stream to data read from.
@@ -104,7 +107,7 @@ public final class CopyJob implements Runnable
       }
       catch ( IOException ioe )
       {
-         ioe.printStackTrace(System.err);
+         log.error(ioe);
       }
       finally
       {
@@ -114,7 +117,7 @@ public final class CopyJob implements Runnable
          }
          catch (IOException ioe)
          {
-            ioe.printStackTrace(System.err);
+            log.error(ioe);
          }
          if (this.closeOsOnExit)
          {
@@ -125,7 +128,7 @@ public final class CopyJob implements Runnable
             }
             catch (IOException ioe)
             {
-               ioe.printStackTrace(System.err);
+               log.error(ioe);
             }
          }
       }
@@ -155,7 +158,7 @@ public final class CopyJob implements Runnable
                }
                catch ( InterruptedException ie )
                {
-                  ie.printStackTrace( System.err );
+                  log.error(ie);
                }
             }
          }

--- a/src/main/java/org/jboss/ws/common/utils/Base64.java
+++ b/src/main/java/org/jboss/ws/common/utils/Base64.java
@@ -336,7 +336,7 @@ public class Base64
       } // end try
       catch (java.io.IOException e)
       {
-         e.printStackTrace();
+         log.error(e);
          return null;
       } // end catch
       finally
@@ -485,7 +485,7 @@ public class Base64
          } // end try
          catch (java.io.IOException e)
          {
-            e.printStackTrace();
+            log.error(e);
             return null;
          } // end catch
          finally
@@ -824,12 +824,12 @@ public class Base64
       } // end try
       catch (java.io.IOException e)
       {
-         e.printStackTrace();
+         log.error(e);
          obj = null;
       } // end catch
       catch (java.lang.ClassNotFoundException e)
       {
-         e.printStackTrace();
+         log.error(e);
          obj = null;
       } // end catch
       finally


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBWS-3997