### PR TITLE
Fix NPE for https://issues.jboss.org/browse/JBWS-4095

### DIFF
--- a/src/main/java/org/jboss/ws/common/utils/DelegateClassLoader.java
+++ b/src/main/java/org/jboss/ws/common/utils/DelegateClassLoader.java
@@ -129,7 +129,11 @@ public class DelegateClassLoader extends SecureClassLoader
    @Override
    public InputStream getResourceAsStream(final String name)
    {
-      InputStream is = parent.getResourceAsStream(name);
+      InputStream is = null;
+      if (parent != null)
+      {
+        is = parent.getResourceAsStream(name);
+      }
       return (is == null) ? delegate.getResourceAsStream(name) : is;
    }
 }


### PR DESCRIPTION
The NullPointerException is happeing in WildFly 11 final during a WebService registration.
Please see https://issues.jboss.org/browse/JBWS-4095